### PR TITLE
GitHub vs Hosted site links

### DIFF
--- a/work.html
+++ b/work.html
@@ -76,7 +76,8 @@
                     written with Node/Express as Lambda functions (FaaS) and is hosted on AWS. The serverless functions
                     connect to the Google Calendar API.
                 </p>
-                <a href="https://cmr927.github.io/meet/">See Meet App on GitHub</a>
+                <a href="https://cmr927.github.io/meet/">cmr927.github.io/meet</a>
+                <a hfref="https://github.com/cmr927/meet">Meet App GitHub repository</a>
             </div>
         </div>
     </section>


### PR DESCRIPTION
GitHub vs Hosted site links